### PR TITLE
[rosdep] fix rosdep install --from-paths

### DIFF
--- a/tmc_wrs_gazebo/package.xml
+++ b/tmc_wrs_gazebo/package.xml
@@ -12,8 +12,8 @@
   <author>Nobuyuki Matsuno</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>tmc_wrs_launch</run_depend>
-  <run_depend>tmc_wrs_worlds</run_depend>
+  <run_depend>tmc_wrs_gazebo_launch</run_depend>
+  <run_depend>tmc_wrs_gazebo_worlds</run_depend>
   <export>
     <metapackage/>
   </export>

--- a/tmc_wrs_gazebo_launch/package.xml
+++ b/tmc_wrs_gazebo_launch/package.xml
@@ -17,8 +17,8 @@
   <run_depend>hsrb_rosnav_config</run_depend>
   <run_depend>hsrb_moveit_config</run_depend>
 
-  <run_depend>hsrb_gazebo_launch</run_depend>
-  <run_depend>hsrb_gazebo_task_evaluators</run_depend>
+  <run_depend>hsrb_wrs_gazebo_launch</run_depend>
+  <run_depend>tmc_gazebo_task_evaluators</run_depend>
   <run_depend>tmc_wrs_gazebo_worlds</run_depend>
   <run_depend>rosbag</run_depend>
   <run_depend>rviz</run_depend>


### PR DESCRIPTION
This change fixes the command:

`rosdep install --from-paths src --ignore-src -r -y`

I noticed this while looking into https://github.com/RoboCupAtHome/RuleBook/issues/731