### PR TITLE
replace xacro.py to xacro

### DIFF
--- a/tmc_wrs_gazebo_worlds/CMakeLists.txt
+++ b/tmc_wrs_gazebo_worlds/CMakeLists.txt
@@ -28,19 +28,19 @@ foreach(_xacro ${_world_xacros})
     add_custom_command(
         OUTPUT ${_default_world}
         DEPENDS ${_xacro} ${_component_xacros}
-        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro.py ${_xacro} fast_physics:=false highrtf:=false trofast_knob:=false > ${_default_world})
+        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro ${_xacro} fast_physics:=false highrtf:=false trofast_knob:=false > ${_default_world})
     add_custom_command(
         OUTPUT ${_default_highrtf_world}
         DEPENDS ${_xacro} ${_component_xacros}
-        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro.py ${_xacro} fast_physics:=false highrtf:=true trofast_knob:=false > ${_default_highrtf_world})
+        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro ${_xacro} fast_physics:=false highrtf:=true trofast_knob:=false > ${_default_highrtf_world})
     add_custom_command(
         OUTPUT ${_fast_world}
         DEPENDS ${_xacro} ${_component_xacros}
-        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro.py ${_xacro} fast_physics:=true highrtf:=false trofast_knob:=false > ${_fast_world})
+        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro ${_xacro} fast_physics:=true highrtf:=false trofast_knob:=false > ${_fast_world})
     add_custom_command(
         OUTPUT ${_fast_highrtf_world}
         DEPENDS ${_xacro} ${_component_xacros}
-        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro.py ${_xacro} fast_physics:=true highrtf:=true trofast_knob:=false > ${_fast_highrtf_world})
+        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro ${_xacro} fast_physics:=true highrtf:=true trofast_knob:=false > ${_fast_highrtf_world})
     add_custom_target(${PROJECT_NAME}_${_name}_gen_default_world ALL DEPENDS ${_default_world})
     add_custom_target(${PROJECT_NAME}_${_name}_gen_default_highrtf_world ALL DEPENDS ${_default_highrtf_world})
     add_custom_target(${PROJECT_NAME}_${_name}_gen_fast_world ALL DEPENDS ${_fast_world})
@@ -49,19 +49,19 @@ foreach(_xacro ${_world_xacros})
     add_custom_command(
         OUTPUT ${_default_knob_world}
         DEPENDS ${_xacro} ${_component_xacros}
-        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro.py ${_xacro} fast_physics:=false highrtf:=false trofast_knob:=true > ${_default_knob_world})
+        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro ${_xacro} fast_physics:=false highrtf:=false trofast_knob:=true > ${_default_knob_world})
     add_custom_command(
         OUTPUT ${_default_highrtf_knob_world}
         DEPENDS ${_xacro} ${_component_xacros}
-        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro.py ${_xacro} fast_physics:=false highrtf:=true trofast_knob:=true > ${_default_highrtf_knob_world})
+        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro ${_xacro} fast_physics:=false highrtf:=true trofast_knob:=true > ${_default_highrtf_knob_world})
     add_custom_command(
         OUTPUT ${_fast_knob_world}
         DEPENDS ${_xacro} ${_component_xacros}
-        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro.py ${_xacro} fast_physics:=true highrtf:=false trofast_knob:=true > ${_fast_knob_world})
+        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro ${_xacro} fast_physics:=true highrtf:=false trofast_knob:=true > ${_fast_knob_world})
     add_custom_command(
         OUTPUT ${_fast_highrtf_knob_world}
         DEPENDS ${_xacro} ${_component_xacros}
-        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro.py ${_xacro} fast_physics:=true highrtf:=true trofast_knob:=true > ${_fast_highrtf_knob_world})
+        COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun xacro xacro ${_xacro} fast_physics:=true highrtf:=true trofast_knob:=true > ${_fast_highrtf_knob_world})
     add_custom_target(${PROJECT_NAME}_${_name}_gen_default_knob_world ALL DEPENDS ${_default_knob_world})
     add_custom_target(${PROJECT_NAME}_${_name}_gen_default_highrtf_knob_world ALL DEPENDS ${_default_highrtf_knob_world})
     add_custom_target(${PROJECT_NAME}_${_name}_gen_fast_knob_world ALL DEPENDS ${_fast_knob_world})


### PR DESCRIPTION
According to [ROS wiki](http://wiki.ros.org/xacro#Processing_Order), calling xacro.py is deprecated since ROS Jade. We should call xacro instead.