### PR TITLE
Fix incorrect collision box for the bookshelf back vertical

### DIFF
--- a/tmc_wrs_gazebo_worlds/models/wrc_bookshelf/model.sdf
+++ b/tmc_wrs_gazebo_worlds/models/wrc_bookshelf/model.sdf
@@ -7,7 +7,7 @@
         <mass>1.0</mass>
       </inertial>
       <collision name="back">
-        <pose>0 0.005 1.02 0 0 0</pose>
+        <pose>0 0.14 1.02 0 0 0</pose>
         <geometry>
           <box>
             <size>0.8 0.02 2.02</size>


### PR DESCRIPTION
The collision box in the SDF file for the bookshelf is placed almost at the center (along the Y-axis) of the bookshelf model. This PR fixes the issue by setting the right y-coordinates for the collision box.

Before fix:
![Issue](https://user-images.githubusercontent.com/9501294/121332406-20b40980-c918-11eb-97f1-3ccc7296fb7c.png)


Fixed:
![Fixed](https://user-images.githubusercontent.com/9501294/121332420-2578bd80-c918-11eb-91ef-d1f7ac140f61.png)
